### PR TITLE
Allow moving entrance nodes

### DIFF
--- a/lib/models/amenity.dart
+++ b/lib/models/amenity.dart
@@ -118,7 +118,8 @@ class OsmChange extends ChangeNotifier implements Comparable {
       (element?.isPoint ?? true) &&
       (element == null || element?.isMember == IsMember.no);
   bool get canMove =>
-      (element?.isPoint ?? true) && (element?.isMember != IsMember.way);
+      (element?.isPoint ?? true) &&
+      (element?.isMember != IsMember.way || hasTag('entrance'));
   String? get mainKey => _mainKey;
 
   void revert() {


### PR DESCRIPTION
## Summary
- permit moving entrance nodes even when they are part of a way

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a44e5e99b883249af7f3622b178ce7